### PR TITLE
Add IRenderWorldLastHandler

### DIFF
--- a/forge/forge_client/src/net/minecraft/src/reforged/IRenderWorldLastHandler.java
+++ b/forge/forge_client/src/net/minecraft/src/reforged/IRenderWorldLastHandler.java
@@ -1,0 +1,16 @@
+/*
+ * This software is provided under the terms of the Minecraft Forge Public 
+ * License v1.0.
+ */
+package net.minecraft.src.reforged;
+
+import net.minecraft.src.RenderGlobal;
+
+public interface IRenderWorldLastHandler {
+	/** Called after rendering all the 3D data of the world.  This is
+	 * called before the user's tool is rendered, but otherwise after all
+	 * 3D content.  It is called twice in anaglyph mode.  This is intended
+	 * for rendering visual effect overlays into the world.
+	 */
+	void onRenderWorldLast(RenderGlobal rg, float f);
+}

--- a/forge/forge_client/src/net/minecraft/src/reforged/ReforgedHooksClient.java
+++ b/forge/forge_client/src/net/minecraft/src/reforged/ReforgedHooksClient.java
@@ -1,0 +1,21 @@
+/**
+ * This software is provided under the terms of the Minecraft Forge Public 
+ * License v1.0.
+ */
+package net.minecraft.src.reforged;
+
+import java.util.LinkedList;
+import net.minecraft.src.RenderGlobal;
+
+public class ReforgedHooksClient {
+
+	public static LinkedList<IRenderWorldLastHandler> renderWorldLastHandlers =
+		new LinkedList<IRenderWorldLastHandler>();
+	
+	public static void onRenderWorldLast(RenderGlobal rg, float f) {
+		for (IRenderWorldLastHandler handler : renderWorldLastHandlers) {
+			handler.onRenderWorldLast(rg,f);
+		}
+	}
+	
+}

--- a/forge/minecraft-win.patch
+++ b/forge/minecraft-win.patch
@@ -1120,16 +1120,17 @@ diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityP
 diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityRenderer.java ../src_work/minecraft/net/minecraft/src/EntityRenderer.java
 --- ../src_base/minecraft/net/minecraft/src/EntityRenderer.java	2021-01-02 01:05:04.683044300 -0800
 +++ ../src_work/minecraft/net/minecraft/src/EntityRenderer.java	2021-01-02 15:55:00.413789400 -0800
-@@ -3,6 +3,8 @@
+@@ -3,6 +3,9 @@
  // Decompiler options: packimports(3) braces deadcode 
  
  package net.minecraft.src;
 +import net.minecraft.src.forge.ForgeHooksClient;
 +import net.minecraft.src.reforged.Reforged;
++import net.minecraft.src.reforged.ReforgedHooksClient;
  
  import java.nio.FloatBuffer;
  import java.util.List;
-@@ -106,46 +108,45 @@
+@@ -106,46 +109,45 @@
              d1 = d = 32D;
          } else
          {
@@ -1201,7 +1202,7 @@ diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityR
              }
          }
  
-@@ -573,8 +574,12 @@
+@@ -573,8 +575,12 @@
              {
                  EntityPlayer entityplayer = (EntityPlayer)entityliving;
                  GL11.glDisable(3008 /*GL_ALPHA_TEST*/);
@@ -1214,7 +1215,7 @@ diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityR
                  GL11.glEnable(3008 /*GL_ALPHA_TEST*/);
              }
              GL11.glBlendFunc(770, 771);
-@@ -619,8 +624,12 @@
+@@ -619,18 +625,25 @@
              {
                  EntityPlayer entityplayer1 = (EntityPlayer)entityliving;
                  GL11.glDisable(3008 /*GL_ALPHA_TEST*/);
@@ -1227,6 +1228,19 @@ diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityR
                  GL11.glEnable(3008 /*GL_ALPHA_TEST*/);
              }
              renderRainSnow(f);
+             GL11.glDisable(2912 /*GL_FOG*/);
+             if(pointedEntity == null);
++		GL11.glPushMatrix();
+             setupFog(0, f);
+             GL11.glEnable(2912 /*GL_FOG*/);
+             renderglobal.renderClouds(f);
+             GL11.glDisable(2912 /*GL_FOG*/);
+             setupFog(1, f);
++		GL11.glPopMatrix();
++		ReforgedHooksClient.onRenderWorldLast(renderglobal,f);
+             if(cameraZoom == 1.0D)
+             {
+                 GL11.glClear(256);
 diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntitySheep.java ../src_work/minecraft/net/minecraft/src/EntitySheep.java
 --- ../src_base/minecraft/net/minecraft/src/EntitySheep.java	2021-01-02 01:05:04.697045000 -0800
 +++ ../src_work/minecraft/net/minecraft/src/EntitySheep.java	2021-01-02 13:42:02.910502400 -0800

--- a/forge/minecraft.patch
+++ b/forge/minecraft.patch
@@ -1240,16 +1240,17 @@ diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityP
 diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityRenderer.java ../src_work/minecraft/net/minecraft/src/EntityRenderer.java
 --- ../src_base/minecraft/net/minecraft/src/EntityRenderer.java	2021-01-03 20:24:40.626037800 -0500
 +++ ../src_work/minecraft/net/minecraft/src/EntityRenderer.java	2021-01-03 20:25:20.047421200 -0500
-@@ -3,6 +3,8 @@
+@@ -3,6 +3,9 @@
  // Decompiler options: packimports(3) braces deadcode 
  
  package net.minecraft.src;
 +import net.minecraft.src.forge.ForgeHooksClient;
 +import net.minecraft.src.reforged.Reforged;
++import net.minecraft.src.reforged.ReforgedHooksClient;
  
  import java.nio.FloatBuffer;
  import java.util.List;
-@@ -106,46 +108,45 @@
+@@ -106,46 +109,45 @@
              d1 = d = 32D;
          } else
          {
@@ -1321,7 +1322,7 @@ diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityR
              }
          }
  
-@@ -573,8 +574,12 @@
+@@ -573,8 +575,12 @@
              {
                  EntityPlayer entityplayer = (EntityPlayer)entityliving;
                  GL11.glDisable(3008 /*GL_ALPHA_TEST*/);
@@ -1334,7 +1335,7 @@ diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityR
                  GL11.glEnable(3008 /*GL_ALPHA_TEST*/);
              }
              GL11.glBlendFunc(770, 771);
-@@ -619,8 +624,12 @@
+@@ -619,18 +625,25 @@
              {
                  EntityPlayer entityplayer1 = (EntityPlayer)entityliving;
                  GL11.glDisable(3008 /*GL_ALPHA_TEST*/);
@@ -1347,6 +1348,19 @@ diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntityR
                  GL11.glEnable(3008 /*GL_ALPHA_TEST*/);
              }
              renderRainSnow(f);
+             GL11.glDisable(2912 /*GL_FOG*/);
+             if(pointedEntity == null);
++		GL11.glPushMatrix();
+             setupFog(0, f);
+             GL11.glEnable(2912 /*GL_FOG*/);
+             renderglobal.renderClouds(f);
+             GL11.glDisable(2912 /*GL_FOG*/);
+             setupFog(1, f);
++		GL11.glPopMatrix();
++		ReforgedHooksClient.onRenderWorldLast(renderglobal,f);
+             if(cameraZoom == 1.0D)
+             {
+                 GL11.glClear(256);
 diff -urN -r --strip-trailing-cr ../src_base/minecraft/net/minecraft/src/EntitySheep.java ../src_work/minecraft/net/minecraft/src/EntitySheep.java
 --- ../src_base/minecraft/net/minecraft/src/EntitySheep.java	2021-01-03 20:24:40.630036000 -0500
 +++ ../src_work/minecraft/net/minecraft/src/EntitySheep.java	2021-01-03 20:25:20.050422900 -0500


### PR DESCRIPTION
This is basically a backport of the `IRenderWorldLastHandler` from Forge MC 1.0.
Useful for rendering world overlays.

And yes, I know, Reforged has not received an update for quite a while, but I would really appreciate this for Block Helper :)

As a temporary solution (if you want to test this), you can use this "thrown-together" release:
~~[reforged-client-1.0.3.zip](https://github.com/user-attachments/files/20054766/reforged-client-1.0.3.zip)~~

I ~~did **NOT** increment the version and~~ did **NOT** provide a new server release as the server files do not change anyway.
If wanted, I can also throw together a preview-`src`-release.

**Update**: I have increased the version and also made all the class files Java 6 compatible here: 
[reforged-client-1.0.3.zip](https://github.com/user-attachments/files/20194648/reforged-client-1.0.3.zip)
There is a good chance that I broke some stuff, though. So, please be extra careful when using that release...